### PR TITLE
Add image preprocessing pipeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,8 +36,17 @@
 		<pre id="jsonOutput"></pre>
 		<script src="./script_v1.js"></script>
 		<script>
-			let img_compress_yn="y";
-			let img_max_file_size_for_compress=1*1024*1024; // 1MB
+                        let img_compress_yn="y";
+                        let img_max_file_size_for_compress=1*1024*1024; // 1MB
+
+                        // Pre-processing toggles
+                        let increase_resolution_yn = "y"; // Increase Resolution for improved OCR accuracy
+                        let contrast_enhance_yn = "y"; // Contrast Enhancement
+                        let adaptive_threshold_yn = "y"; // Adaptive Thresholding
+                        let deskew_yn = "y"; // Deskew / Rotation Correction
+                        let noise_median_yn = "y"; // Noise Reduction (Median)
+                        let noise_gaussian_yn = "y"; // Noise Reduction (Gaussian)
+                        let sharpen_image_yn = "y"; // Sharpen Image
 			
 			function compressImage(file, quality=0.8){
 				return new Promise((resolve,reject)=>{
@@ -90,14 +99,165 @@
 				tbody.innerHTML='';
 				if(Array.isArray(data.items)) data.items.forEach(addItemRow);
 			}
-			function fileToBase64(file){
-				return new Promise((resolve,reject)=>{
-					const r=new FileReader();
-					r.onload=()=>resolve(r.result.split(',')[1]);
-					r.onerror=reject;
-					r.readAsDataURL(file);
-				});
-			}
+                        function fileToBase64(file){
+                                return new Promise((resolve,reject)=>{
+                                        const r=new FileReader();
+                                        r.onload=()=>resolve(r.result.split(',')[1]);
+                                        r.onerror=reject;
+                                        r.readAsDataURL(file);
+                                });
+                        }
+
+                        // --- Image Pre-processing helpers ---
+
+                        function loadImageFile(file){
+                                return new Promise((resolve,reject)=>{
+                                        const reader=new FileReader();
+                                        reader.onload=ev=>{
+                                                const img=new Image();
+                                                img.onload=()=>resolve(img);
+                                                img.onerror=reject;
+                                                img.src=ev.target.result;
+                                        };
+                                        reader.onerror=reject;
+                                        reader.readAsDataURL(file);
+                                });
+                        }
+
+                        function getOrientation(file){
+                                return new Promise((resolve)=>{
+                                        const reader=new FileReader();
+                                        reader.onload=function(e){
+                                                const view=new DataView(e.target.result);
+                                                if(view.getUint16(0,false)!==0xFFD8) return resolve(1);
+                                                let length=view.byteLength,offset=2;
+                                                while(offset<length){
+                                                        const marker=view.getUint16(offset,false);
+                                                        offset+=2;
+                                                        if(marker===0xFFE1){
+                                                                offset+=2;
+                                                                if(view.getUint32(offset,false)!==0x45786966) break;
+                                                                offset+=6;
+                                                                const little=view.getUint16(offset,false)===0x4949;
+                                                                offset+=view.getUint32(offset+4,little);
+                                                                const tags=view.getUint16(offset,little);offset+=2;
+                                                                for(let i=0;i<tags;i++){
+                                                                        if(view.getUint16(offset+i*12,little)===0x0112){
+                                                                                resolve(view.getUint16(offset+i*12+8,little));
+                                                                                return;
+                                                                        }
+                                                                }
+                                                                break;
+                                                        }else if((marker&0xFF00)!==0xFF00) break;
+                                                        else offset+=view.getUint16(offset,false);
+                                                }
+                                                resolve(1);
+                                        };
+                                        reader.readAsArrayBuffer(file);
+                                });
+                        }
+
+                        function applyOrientation(canvas,ctx,img,orientation){
+                                switch(orientation){
+                                        case 3: ctx.translate(canvas.width,canvas.height); ctx.rotate(Math.PI); break;
+                                        case 6: canvas.width=img.height; canvas.height=img.width; ctx.rotate(0.5*Math.PI); ctx.translate(0,-canvas.width); break;
+                                        case 8: canvas.width=img.height; canvas.height=img.width; ctx.rotate(-0.5*Math.PI); ctx.translate(-canvas.height,0); break;
+                                        default: break;
+                                }
+                        }
+
+                        function histogramEqualization(imageData){
+                                const data=imageData.data; const hist=new Array(256).fill(0);
+                                for(let i=0;i<data.length;i+=4) hist[data[i]]++;
+                                for(let i=1;i<256;i++) hist[i]+=hist[i-1];
+                                const total=hist[255]; const lut=new Array(256);
+                                for(let i=0;i<256;i++) lut[i]=Math.round((hist[i]-hist[0])*255/(total-hist[0]));
+                                for(let i=0;i<data.length;i+=4){const v=lut[data[i]]; data[i]=data[i+1]=data[i+2]=v;}
+                        }
+
+                        function thresholdImage(imageData){
+                                const data=imageData.data; let sum=0,count=0;
+                                for(let i=0;i<data.length;i+=4){sum+=data[i]; count++;}
+                                const avg=sum/count;
+                                for(let i=0;i<data.length;i+=4){const v=data[i]<avg?0:255; data[i]=data[i+1]=data[i+2]=v;}
+                        }
+
+                        function convolve(src,width,height,kernel,div){
+                                const out=new Uint8ClampedArray(src.data.length);
+                                const data=src.data;
+                                for(let y=1;y<height-1;y++){
+                                        for(let x=1;x<width-1;x++){
+                                                let sum=0,ki=0;
+                                                for(let ky=-1;ky<=1;ky++){
+                                                        for(let kx=-1;kx<=1;kx++){
+                                                                const i=((y+ky)*width+(x+kx))*4;
+                                                                sum+=data[i]*kernel[ki++];
+                                                        }
+                                                }
+                                                const v=Math.min(255,Math.max(0,sum/div));
+                                                const idx=(y*width+x)*4;
+                                                out[idx]=out[idx+1]=out[idx+2]=v; out[idx+3]=255;
+                                        }
+                                }
+                                src.data.set(out);
+                        }
+
+                        function medianFilter(src,width,height){
+                                const out=new Uint8ClampedArray(src.data.length);
+                                const data=src.data;
+                                for(let y=1;y<height-1;y++){
+                                        for(let x=1;x<width-1;x++){
+                                                const vals=[];
+                                                for(let ky=-1;ky<=1;ky++){
+                                                        for(let kx=-1;kx<=1;kx++){
+                                                                const i=((y+ky)*width+(x+kx))*4;
+                                                                vals.push(data[i]);
+                                                        }
+                                                }
+                                                vals.sort((a,b)=>a-b);
+                                                const m=vals[4];
+                                                const idx=(y*width+x)*4;
+                                                out[idx]=out[idx+1]=out[idx+2]=m; out[idx+3]=255;
+                                        }
+                                }
+                                src.data.set(out);
+                        }
+
+                        async function preprocessImage(file){
+                                const img=await loadImageFile(file);
+                                const orientation=deskew_yn==='y'?await getOrientation(file):1;
+
+                                let canvas=document.createElement('canvas');
+                                canvas.width=img.width; canvas.height=img.height;
+                                const ctx=canvas.getContext('2d');
+                                applyOrientation(canvas,ctx,img,orientation);
+                                ctx.drawImage(img,0,0);
+
+                                if(increase_resolution_yn==='y'){
+                                        const scale=2;
+                                        const c2=document.createElement('canvas');
+                                        c2.width=canvas.width*scale; c2.height=canvas.height*scale;
+                                        c2.getContext('2d').drawImage(canvas,0,0,c2.width,c2.height);
+                                        canvas=c2;
+                                }
+
+                                let imageData=canvas.getContext('2d').getImageData(0,0,canvas.width,canvas.height);
+
+                                // convert to grayscale
+                                for(let i=0;i<imageData.data.length;i+=4){
+                                        const avg=(imageData.data[i]+imageData.data[i+1]+imageData.data[i+2])/3;
+                                        imageData.data[i]=imageData.data[i+1]=imageData.data[i+2]=avg;
+                                }
+
+                                if(contrast_enhance_yn==='y') histogramEqualization(imageData);
+                                if(adaptive_threshold_yn==='y') thresholdImage(imageData);
+                                if(noise_median_yn==='y') medianFilter(imageData,canvas.width,canvas.height);
+                                if(noise_gaussian_yn==='y') convolve(imageData,canvas.width,canvas.height,[1,2,1,2,4,2,1,2,1],16);
+                                if(sharpen_image_yn==='y') convolve(imageData,canvas.width,canvas.height,[0,-1,0,-1,5,-1,0,-1,0],1);
+
+                                canvas.getContext('2d').putImageData(imageData,0,0);
+                                return new Promise(res=>canvas.toBlob(b=>res(new File([b],file.name,{type:'image/png'})),'image/png'));
+                        }
 			
 			// Extract the first JSON object found in the given text
 			function extractJSON(text){
@@ -278,16 +438,17 @@
 				try{
 					const files=document.getElementById('imageInput').files;
 					let combined={to:'',from:'',items:[]};
-					for(const f of files){
-						try{
-							const file=await compressIfNeeded(f);
-							const json=await sendOCR(file);
-							if(json.to) combined.to=json.to;
-							if(json.from) combined.from=json.from;
-							if(Array.isArray(json.items)) combined.items.push(...json.items);
-						}catch(err){
-							alert(err.message);
-						}
+                                        for(const f of files){
+                                                try{
+                                                        const pre=await preprocessImage(f);
+                                                        const file=await compressIfNeeded(pre);
+                                                        const json=await sendOCR(file);
+                                                        if(json.to) combined.to=json.to;
+                                                        if(json.from) combined.from=json.from;
+                                                        if(Array.isArray(json.items)) combined.items.push(...json.items);
+                                                }catch(err){
+                                                        alert(err.message);
+                                                }
 					}
 					// Results should already be sanitized by the language model
 					document.getElementById('jsonOutput').textContent=JSON.stringify(combined,null,2);


### PR DESCRIPTION
## Summary
- add toggles for each preprocessing step
- implement preprocessing helpers and pipeline
- preprocess each uploaded image before sending to OCR

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_683faeb6a6f08331a03d38b752fe0057