### PR TITLE
Fix preprocessing settings persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -555,14 +555,20 @@
                                 showPreview();
                                 modal.classList.add('show');
                         });
-                        document.getElementById('closeModal').addEventListener('click',()=>modal.classList.remove('show'));
+                        document.getElementById('closeModal').addEventListener('click',()=>{
+                                applyCheckboxes();
+                                modal.classList.remove('show');
+                        });
                         document.getElementById('runOCRModal').addEventListener('click',()=>{
                                 applyCheckboxes();
                                 modal.classList.remove('show');
                                 runOCR();
                         });
 
-                        document.getElementById('ocrBtn').addEventListener('click',runOCR);
+                        document.getElementById('ocrBtn').addEventListener('click',()=>{
+                                applyCheckboxes();
+                                runOCR();
+                        });
                         addItemRow();
 		</script>
 	</body>


### PR DESCRIPTION
## Summary
- ensure preprocessing checkbox states persist when closing the modal
- apply settings when using the main Upload & OCR button

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_683fb60434848331b05b3850b61fde9e