### PR TITLE
Add simple analytics chat demo

### DIFF
--- a/agent_prompt_example.md
+++ b/agent_prompt_example.md
@@ -1,0 +1,14 @@
+You are an AI agent that receives user questions about business analytics.
+- Decide if the query is a chat (definition/explanation) or if it needs SQL/database access.
+- If SQL is needed:
+    - Generate the SQL using only the provided table schema
+    - Briefly explain your logic
+    - Do not invent fields or data
+- Log every step, decision, and SQL in a step-by-step debug array
+- Output should be JSON:
+  - "mode": "chat" or "sql"
+  - "debug": [step1, step2, ...]
+  - "sql": "" (if not used)
+  - "response": final message for user
+Schema:
+  sales(id, date, amount, customer_name)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Business Analytics Chat</title>
+    <style>
+        body { font-family: Arial, sans-serif; background:#f7f7f7; margin:0; padding:20px; }
+        .chat-container { max-width:800px; margin:auto; background:#fff; border-radius:8px; box-shadow:0 0 10px rgba(0,0,0,0.1); padding:20px; }
+        #messages { min-height:200px; }
+        .msg { margin:10px 0; }
+        .user { font-weight:bold; }
+        .bot { color:#333; }
+        #debug { background:#fafafa; border:1px solid #ddd; padding:10px; margin-top:20px; font-size:0.9em; max-height:200px; overflow:auto; }
+        form { display:flex; gap:10px; margin-top:15px; }
+        input[type="text"] { flex:1; padding:10px; border:1px solid #ccc; border-radius:4px; }
+        button { padding:10px 15px; }
+        table { border-collapse: collapse; width:100%; margin-top:10px; }
+        th,td { border:1px solid #ccc; padding:5px; text-align:left; }
+    </style>
+</head>
+<body>
+<div class="chat-container">
+    <div id="messages"></div>
+    <form id="chat-form">
+        <input id="user-input" type="text" placeholder="Ask a question..." autocomplete="off" required>
+        <button type="submit">Send</button>
+    </form>
+    <div id="debug"></div>
+</div>
+<script>
+const OPENAI_API_KEY = 'YOUR_API_KEY'; // replace with your key
+const systemPrompt = `You are an AI agent that receives user questions about business analytics.\n- Decide if the query is a chat (definition/explanation) or if it needs SQL/database access.\n- If SQL is needed:\n    - Generate the SQL using only the provided table schema\n    - Briefly explain your logic\n    - Do not invent fields or data\n- Log every step, decision, and SQL in a step-by-step debug array\n- Output JSON {"mode":"chat|sql","debug":[],"sql":"","response":""}\nSchema:\nsales(id:int,date:date,amount:decimal,customer_name:varchar)`;
+let history = [];
+
+function addMessage(role, text){
+    const div = document.createElement('div');
+    div.className='msg '+role;
+    div.textContent=role+': '+text;
+    document.getElementById('messages').appendChild(div);
+}
+function addDebug(text){
+    const p = document.createElement('div');
+    p.textContent=text;
+    document.getElementById('debug').appendChild(p);
+}
+async function callAgent(text){
+    const messages=[{role:'system',content:systemPrompt},...history,{role:'user',content:text}];
+    const res = await fetch('https://api.openai.com/v1/chat/completions',{
+        method:'POST',
+        headers:{'Content-Type':'application/json','Authorization':'Bearer '+OPENAI_API_KEY},
+        body:JSON.stringify({model:'gpt-4',messages,temperature:0})
+    });
+    const data = await res.json();
+    const content = data.choices[0].message.content.trim();
+    return JSON.parse(content);
+}
+async function runSQL(sql){
+    const res = await fetch('runQuery.cfm?sql='+encodeURIComponent(sql));
+    return res.json();
+}
+document.getElementById('chat-form').addEventListener('submit', async (e)=>{
+    e.preventDefault();
+    const input = document.getElementById('user-input');
+    const text = input.value.trim();
+    if(!text) return;
+    input.value='';
+    addMessage('user', text);
+    const agent = await callAgent(text);
+    agent.debug.forEach(addDebug);
+    let reply = agent.response;
+    if(agent.mode==='sql' && agent.sql){
+        const data = await runSQL(agent.sql);
+        if(data.rows){
+            const table = document.createElement('table');
+            const header = document.createElement('tr');
+            Object.keys(data.rows[0]||{}).forEach(col=>{
+                const th=document.createElement('th'); th.textContent=col; header.appendChild(th);
+            });
+            table.appendChild(header);
+            data.rows.forEach(row=>{
+                const tr=document.createElement('tr');
+                Object.values(row).forEach(val=>{ const td=document.createElement('td'); td.textContent=val; tr.appendChild(td);});
+                table.appendChild(tr);
+            });
+            document.getElementById('messages').appendChild(table);
+        }
+    }
+    addMessage('bot', reply);
+    history.push({role:'user',content:text});
+    history.push({role:'assistant',content:reply});
+});
+</script>
+</body>
+</html>

--- a/runQuery.cfm
+++ b/runQuery.cfm
@@ -1,0 +1,26 @@
+<cfcontent type="application/json" />
+<cfheader name="Access-Control-Allow-Origin" value="*" />
+<cfparam name="url.sql" default="" />
+<cfif NOT len(url.sql)>
+    <cfoutput>#serializeJSON({"error":"Missing SQL"})#</cfoutput>
+    <cfabort>
+</cfif>
+<!--- Attempt SQL execution --->
+<cfset sqlOut = url.sql />
+<cftry>
+    <cfquery name="q" datasource="#cookie.cooksql_mainsync#_active" timeout="30">
+        #preserveSingleQuotes(sqlOut)#
+    </cfquery>
+    <cfset rows = []>
+    <cfloop query="q">
+        <cfset row = structNew()>
+        <cfloop list="#q.columnList#" index="c">
+            <cfset row[c] = q[c][currentRow]>
+        </cfloop>
+        <cfset arrayAppend(rows,row)>
+    </cfloop>
+    <cfoutput>#serializeJSON({rows:rows})#</cfoutput>
+    <cfcatch>
+        <cfoutput>#serializeJSON({error:cfcatch.message})#</cfoutput>
+    </cfcatch>
+</cftry>


### PR DESCRIPTION
## Summary
- provide minimal front-end in `index.html` to query an AI agent and show debug output
- create `runQuery.cfm` endpoint for executing SQL queries
- add an example system prompt for the AI agent
- remove outdated sample data and refine query logic

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68412db977008331b3a16e7aec94fa22