### PR TITLE
Fix struct check in ask.cfm

### DIFF
--- a/ask.cfm
+++ b/ask.cfm
@@ -23,7 +23,7 @@
 </cfloop>
 <cfset rulesSummary = "">
 <cfloop collection="#schema#" item="tbl">
-    <cfif structKeyExists(schema[tbl], "business_rules")> 
+    <cfif isStruct(schema[tbl]) AND structKeyExists(schema[tbl], "business_rules")>
         <cfset rulesSummary &= "* " & tbl & ": " & arrayToList(schema[tbl]["business_rules"], "; ") & "\n">
     </cfif>
 </cfloop>


### PR DESCRIPTION
## Summary
- avoid calling structKeyExists on array data

## Testing
- `lucee --help` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684177e96d7083318ff449df87a9eb99