### PR TITLE
Add datalist suggestions on focus

### DIFF
--- a/index.cfm
+++ b/index.cfm
@@ -38,6 +38,9 @@
     const $form = document.getElementById('qform');
     const $msg = document.getElementById('msg');
     const $result = document.getElementById('result');
+    $msg.addEventListener('focus', () => {
+        $msg.dispatchEvent(new Event('input', {bubbles: true}));
+    });
     $form.onsubmit = async (e) => {
         e.preventDefault();
         $result.innerHTML = "Generating report...";


### PR DESCRIPTION
## Summary
- show datalist suggestions as soon as the input is focused by dispatching an input event

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68493875e01c833197e525889068a748