### PR TITLE
Fix ai_agent prompt format

### DIFF
--- a/ai_agent.cfm
+++ b/ai_agent.cfm
@@ -37,9 +37,7 @@
 	#schemaString#
 	````
 	
-	User question:
-	\#userMsg#
-	">
+        ">
 	
 	<cfset aiSession = LuceeCreateAISession(name="gpt001", systemMessage=aiPrompt)>
 	<cfset aiSql = LuceeInquiryAISession(aiSession, userMsg)>


### PR DESCRIPTION
## Summary
- update ai_prompt so it ends after the schema block

## Testing
- `lucee` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684941715ea08331a970dd47ed7c6553