### PR TITLE
Fix closing code block delimiter in ai_agent.cfm

### DIFF
--- a/ai_agent.cfm
+++ b/ai_agent.cfm
@@ -33,9 +33,9 @@
 	- **Respond ONLY with the SQL (no explanations or comments)**
 	
 	Database schema:
-	```json
-	#schemaString#
-	````
+        ```json
+        #schemaString#
+        ```
 	
         ">
 	


### PR DESCRIPTION
## Summary
- correct the closing backtick delimiter around the schema block in `ai_agent.cfm`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849423f09b883318da2cce5d16c7a77