### PR TITLE
Add session history for conversation

### DIFF
--- a/ai_agent.cfm
+++ b/ai_agent.cfm
@@ -2,6 +2,10 @@
 <cfcontent type="application/json">
 
 <cftry>
+    <!--- Initialize history array in the session --->
+    <cfif NOT structKeyExists(session, "history") OR NOT isArray(session.history)>
+        <cfset session.history = []>
+    </cfif>
     <!--- 1. Get user input --->
     <cfparam name="form.msg" default="">
     <cfparam name="url.msg" default="">
@@ -102,6 +106,14 @@
             <!--- If summarization fails, fall back to basic summary --->
         </cfcatch>
     </cftry>
+    <!--- Update session history --->
+    <cfset arrayAppend(session.history, {
+        user = userMsg,
+        summary = summary,
+        sql = sql,
+        table = prettyTable
+    })>
+
     <cfoutput>
     #serializeJSON({
         summary = summary,
@@ -109,6 +121,7 @@
         schema = schema,
         table = prettyTable,
         rowCount = data.recordCount,
+        history = session.history,
         debug = { aiPrompt = aiPrompt, aiSql = aiSql, aiSummary = aiSummary }
     })#
     </cfoutput>

--- a/index.cfm
+++ b/index.cfm
@@ -195,14 +195,31 @@
                 return;
             }
 
-            const temp_sql = j.SQL;
-            const temp_table = j.TABLE;
-            const temp_summary = j.SUMMARY;
+            if (Array.isArray(j.history)) {
+                $thread.innerHTML = '';
+                j.history.forEach(item => {
+                    const ue = document.createElement('div');
+                    ue.className = 'msg user';
+                    ue.textContent = item.user;
+                    $thread.appendChild(ue);
 
-            aiEl.innerHTML =
-                '<div><b>' + (temp_summary || '') + '</b></div>' +
-                (temp_sql ? `<div class="sql-debug">SQL: ${temp_sql}</div>` : '') +
-                (temp_table ? temp_table : '');
+                    const ae = document.createElement('div');
+                    ae.className = 'msg ai';
+                    ae.innerHTML =
+                        '<div><b>' + (item.summary || '') + '</b></div>' +
+                        (item.sql ? `<div class="sql-debug">SQL: ${item.sql}</div>` : '') +
+                        (item.table ? item.table : '');
+                    $thread.appendChild(ae);
+                });
+            } else {
+                const temp_sql = j.SQL;
+                const temp_table = j.TABLE;
+                const temp_summary = j.SUMMARY;
+                aiEl.innerHTML =
+                    '<div><b>' + (temp_summary || '') + '</b></div>' +
+                    (temp_sql ? `<div class="sql-debug">SQL: ${temp_sql}</div>` : '') +
+                    (temp_table ? temp_table : '');
+            }
         } catch (ex) {
             aiEl.innerHTML = '<b>Unexpected error:</b> ' + ex;
         }


### PR DESCRIPTION
## Summary
- persist chat history across requests using the session scope
- return history from `ai_agent.cfm`
- render full history in the thread on the frontend

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849535c498c83318606ec50fdc26fb3