### PR TITLE
Improve debug output

### DIFF
--- a/ai_agent.cfm
+++ b/ai_agent.cfm
@@ -30,6 +30,7 @@
     <cfset sql = "">
     <cfset data = queryNew("")>
     <cfset aiSql = "">
+    <cfset debugMsg = "">
     <cfif plan.database>
         <cfset aiSql = generateSQL(schemaString, userMsg)>
         <cfset sql = aiSql>
@@ -44,6 +45,9 @@
                 <cfoutput>#serializeJSON({error="SQL execution failed", details=cfcatch.message, sql=sql})#</cfoutput><cfabort>
             </cfcatch>
         </cftry>
+        <cfif NOT data.recordCount>
+            <cfset debugMsg = "Query returned 0 rows"> 
+        </cfif>
     </cfif>
 
     <!--- Table agent --->
@@ -67,6 +71,9 @@
     <cfset result.rowCount = data.recordCount>
     <cfset result.schema = schema>
     <cfset result.debug = { plan=plan, aiSql=aiSql }>
+    <cfif len(debugMsg)>
+        <cfset result.debug.message = debugMsg>
+    </cfif>
     <cfoutput>#serializeJSON(result)#</cfoutput>
     <cfcatch>
         <cfoutput>#serializeJSON({error="Unexpected server error", details=cfcatch.message})#</cfoutput>

--- a/index.cfm
+++ b/index.cfm
@@ -190,6 +190,7 @@
             const r = await fetch('ai_agent.cfm', { method: 'POST', body: fd });
             const j = await r.json();
             console.log(j);
+            if (j.debug) console.log('debug:', j.debug);
             if (j.error) {
                 aiEl.textContent = '';
                 const errLabel = document.createElement('b');
@@ -199,6 +200,14 @@
                 if (j.details) {
                     aiEl.appendChild(document.createElement('br'));
                     aiEl.appendChild(document.createTextNode(j.details));
+                }
+                if (j.debug) {
+                    const pre = document.createElement('pre');
+                    pre.className = 'sql-debug';
+                    pre.textContent =
+                        typeof j.debug === 'object' ? JSON.stringify(j.debug, null, 2) : j.debug;
+                    aiEl.appendChild(document.createElement('br'));
+                    aiEl.appendChild(pre);
                 }
                 return;
             }


### PR DESCRIPTION
## Summary
- add a `debugMsg` string when queries return no rows
- show debug text in the UI when an error is returned and log to the debug panel

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684a2a1dbcf08331996665b824261267