### PR TITLE
Add error handling for AI session

### DIFF
--- a/agents.cfm
+++ b/agents.cfm
@@ -7,7 +7,7 @@
     <cfreturn plan>
 </cffunction>
 
-<cffunction name="generateSQL" output="false" returnType="string">
+<cffunction name="generateSQL" output="false" returnType="any">
     <cfargument name="schemaString" type="string" required="true">
     <cfargument name="userMsg" type="string" required="true">
     <cfset var aiPrompt = "You are an expert business analyst and SQL developer.\n\n" &
@@ -20,8 +20,15 @@
         "- If more than one table is relevant, use JOIN as needed" &
         "- Respond ONLY with the SQL (no explanations or comments)" &
         "\n\nDatabase schema:\n```json\n" & arguments.schemaString & "\n```">
-    <cfset var aiSession = LuceeCreateAISession(name="gpt001", systemMessage=aiPrompt)>
-    <cfset var aiSql = LuceeInquiryAISession(aiSession, arguments.userMsg)>
+    <cfset var aiSql = "">
+    <cftry>
+        <cfset var aiSession = LuceeCreateAISession(name="gpt001", systemMessage=aiPrompt)>
+        <cfset aiSql = LuceeInquiryAISession(aiSession, arguments.userMsg)>
+        <cfcatch>
+            <cflog type="error" text="generateSQL: #cfcatch.message#"/>
+            <cfreturn { error="AI session failed", details=cfcatch.message }>
+        </cfcatch>
+    </cftry>
     <!--- Extract first SELECT statement --->
     <cfset var sql = "">
     <cfif refindnocase("^select\\s", aiSql)>

--- a/ai_agent.cfm
+++ b/ai_agent.cfm
@@ -32,11 +32,15 @@
     <cfset aiSql = "">
     <cfset debugMsg = "">
     <cfif plan.database>
-        <cfset aiSql = generateSQL(schemaString, userMsg)>
-        <cfset sql = aiSql>
-        <cfif NOT len(sql) OR NOT refindnocase("^select\\s", sql)>
-            <cfoutput>#serializeJSON({error="AI did not generate valid SQL", debug=aiSql})#</cfoutput><cfabort>
-        </cfif>
+    <cfset aiSqlResult = generateSQL(schemaString, userMsg)>
+    <cfif isStruct(aiSqlResult)>
+        <cfoutput>#serializeJSON({error=aiSqlResult.error ?: "AI session error", details=aiSqlResult.details})#</cfoutput><cfabort>
+    </cfif>
+    <cfset aiSql = aiSqlResult>
+    <cfset sql = aiSql>
+    <cfif NOT len(sql) OR NOT refindnocase("^select\\s", sql)>
+        <cfoutput>#serializeJSON({error="AI did not generate valid SQL", debug=aiSql})#</cfoutput><cfabort>
+    </cfif>
         <cftry>
             <cfquery name="data" datasource="#cookie.cooksql_mainsync#_active" timeout="20">
                 #preserveSingleQuotes(sql)#


### PR DESCRIPTION
## Summary
- handle AI session failures in `generateSQL`
- surface AI errors in `ai_agent.cfm`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684a2c785f488331a657d4d99ccdbd45