### PR TITLE
Fix table header concat bug

### DIFF
--- a/agents.cfm
+++ b/agents.cfm
@@ -51,7 +51,7 @@
         <cfset tableHTML &= "<div style='max-height: 200px;overflow: auto;'>">
         <cfset tableHTML &= "<table class='biz-table'><thead><tr>">
         <cfloop list="#arguments.data.columnlist#" index="col">
-            <cfset tableHTML &= "<th">#encodeForHTML(col)#</th>">
+            <cfset tableHTML &= "<th>" & encodeForHTML(col) & "</th>">
         </cfloop>
         <cfset tableHTML &= "</tr></thead><tbody>">
         <cfloop query="arguments.data">


### PR DESCRIPTION
## Summary
- fix table header concatenation in `renderTable`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684a3030299c8331a67103b0a8cf60f6