### PR TITLE
Limit stored conversation history

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This project is a simple CFML application showcasing an AI agent that generates 
 2. Ensure the datasource for your database is configured on the server.
 3. Set a cookie named `cooksql_mainsync` with the base name of the datasource. The application appends `_active` to this value when executing queries.
 4. Open `index.cfm` in your browser and ask a question about the data.
+5. Each session remembers only the last 20 exchanges to limit memory usage.
 
 ## Debug logs
 

--- a/ai_agent.cfm
+++ b/ai_agent.cfm
@@ -79,6 +79,10 @@
     <!--- Conversation agent --->
     <cfset result = formatConversation(summary, sql, prettyTable)>
     <cfset arrayAppend(session.history, { user=userMsg, summary=summary, sql=sql, table=prettyTable })>
+    <!--- Keep only last 20 exchanges --->
+    <cfloop condition="arrayLen(session.history) GT 20">
+        <cfset arrayDeleteAt(session.history, 1)>
+    </cfloop>
     <cfset result.history = session.history>
     <cfset result.rowCount = data.recordCount>
     <cfset result.schema = schema>


### PR DESCRIPTION
## Summary
- keep only the last 20 messages in session history
- note the conversation limit in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a322029b08331be780753ab408cf5