### PR TITLE
Improve SQL validation and security docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ This project is a simple CFML application showcasing an AI agent that generates 
 4. Open `index.cfm` in your browser and ask a question about the data.
 5. Each session remembers only the last 20 exchanges to limit memory usage.
 
+## Security considerations
+
+The server validates the AI-generated SQL with a simple parser to ensure it is
+only a single `SELECT` statement. Any query that does not meet this criteria is
+rejected before execution. For additional safety, configure the datasource to
+use a database account that has read-only permissions on the relevant tables.
+
 ## Debug logs
 
 Any debug output from the AI agent is sent back in the JSON response under the `debug` key. The front‑end displays these messages in the **Debug Log** box beneath the chat and also logs them to the browser console. Use this information to inspect the generated SQL and the planner output.

--- a/agents.cfm
+++ b/agents.cfm
@@ -36,8 +36,30 @@
     <cfelse>
         <cfset var m = rematchnocase("select\\s.+?(?=;|\\s*$)", aiSql)>
         <cfif arraylen(m)> <cfset sql = trim(m[1])> </cfif>
-    </cfif>
+</cfif>
     <cfreturn sql>
+</cffunction>
+
+<cffunction name="isValidSelect" output="false" returnType="boolean">
+    <cfargument name="sql" type="string" required="true">
+    <cfset var s = trim(arguments.sql)>
+    <!--- must start with SELECT --->
+    <cfif NOT refindnocase("^select\\b", s)>
+        <cfreturn false>
+    </cfif>
+    <!--- allow at most one semicolon and only at the end --->
+    <cfif listLen(s, ";") GT 1>
+        <cfreturn false>
+    </cfif>
+    <cfset var semiPos = find(";", s)>
+    <cfif semiPos AND semiPos LT len(s)>
+        <cfreturn false>
+    </cfif>
+    <!--- reject other statement types --->
+    <cfif refindnocase("\\b(insert|update|delete|drop|create|alter)\\b", s)>
+        <cfreturn false>
+    </cfif>
+    <cfreturn true>
 </cffunction>
 
 <cffunction name="renderTable" output="false" returnType="string">

--- a/ai_agent.cfm
+++ b/ai_agent.cfm
@@ -37,9 +37,12 @@
         <cfoutput>#serializeJSON({error=aiSqlResult.error ?: "AI session error", details=aiSqlResult.details})#</cfoutput><cfabort>
     </cfif>
     <cfset aiSql = aiSqlResult>
-    <cfset sql = aiSql>
-    <cfif NOT len(sql) OR NOT refindnocase("^select\\s", sql)>
+    <cfset sql = trim(aiSql)>
+    <cfif NOT isValidSelect(sql)>
         <cfoutput>#serializeJSON({error="AI did not generate valid SQL", debug=aiSql})#</cfoutput><cfabort>
+    </cfif>
+    <cfif right(sql,1) EQ ";">
+        <cfset sql = left(sql, len(sql)-1)>
     </cfif>
     <!--- Ensure the datasource cookie is present before querying --->
     <cfif NOT structKeyExists(cookie, "cooksql_mainsync")>


### PR DESCRIPTION
## Summary
- validate the generated SQL with a new `isValidSelect` helper
- sanitize SQL in the request handler
- document validation and DB user restrictions in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a33faceb48331adddc90c0cd90a9c