### PR TITLE
Add AI SQL debug details

### DIFF
--- a/ai_agent.cfm
+++ b/ai_agent.cfm
@@ -40,7 +40,7 @@
     <cfset aiSql = aiSqlResult>
     <cfset sql = trim(aiSql)>
     <cfif NOT isValidSelect(sql)>
-        <cfoutput>#serializeJSON({error="AI did not generate valid SQL", debug={sql=aiSql, requestId=requestId}})#</cfoutput><cfabort>
+        <cfoutput>#serializeJSON({error="AI did not generate valid SQL", debug={requestId=requestId, plan=plan, aiResponse=aiSql}})#</cfoutput><cfabort>
     </cfif>
     <cfif right(sql,1) EQ ";">
         <cfset sql = left(sql, len(sql)-1)>

--- a/index.cfm
+++ b/index.cfm
@@ -197,7 +197,10 @@
             const r = await fetch('ai_agent.cfm', { method: 'POST', body: fd });
             const j = await r.json();
             console.log(j);
-            if (j.debug) console.log('debug:', j.debug);
+            if (j.debug) {
+                console.log('debug:', j.debug);
+                if (j.debug.aiResponse) console.log('aiResponse:', j.debug.aiResponse);
+            }
             if (j.error) {
                 aiEl.textContent = '';
                 const errLabel = document.createElement('b');


### PR DESCRIPTION
## Summary
- include `plan` and `aiResponse` when SQL validation fails
- display the raw AI response in the browser debug log

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a39d24990833182b9b3d01ac85afa