### PR TITLE
Remove image embedding alert for Excel export

### DIFF
--- a/demo002/js/export_to_excel.js
+++ b/demo002/js/export_to_excel.js
@@ -8,7 +8,6 @@
     EDGE_TOLERANCE_PX: 1,
     IMAGE_FORMAT: 'image/png',
     BUTTON_BUSY_TEXT: 'Exporting...',
-    IMAGE_WARNING_TEXT: 'Some images could not be embedded. They may be missing in the Excel file.',
     DEBUG: true,
     LOG_PREFIX: '[export]'
   };
@@ -643,7 +642,6 @@
 
     if (failedImages.length) {
       warnLog('Images could not be embedded', failedImages.map((f) => f.element?.src || '(unknown src)'));
-      alert(CONFIG.IMAGE_WARNING_TEXT);
     }
 
     let buffer;


### PR DESCRIPTION
## Summary
- remove the unused image embedding warning text constant
- stop showing the alert dialog when images fail to embed while still logging the warning

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db83f2ea1883319d17003e286a5e64