### PR TITLE
Keep export button text unchanged during Excel export

### DIFF
--- a/demo002/js/export_to_excel.js
+++ b/demo002/js/export_to_excel.js
@@ -671,7 +671,6 @@
       if (button.dataset.busy === '1') return;
       button.dataset.busy = '1';
       const originalText = button.textContent;
-      button.textContent = CONFIG.BUTTON_BUSY_TEXT;
       button.disabled = true;
       try {
         debugLog('Button clicked, starting export');


### PR DESCRIPTION
## Summary
- remove the temporary busy text assignment in the export button click handler so the label stays constant during exports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db92670f60833181f58fd3564f907f