### PR TITLE
Handle alpha transparency in Excel export colors

### DIFF
--- a/demo002/js/export_to_excel.js
+++ b/demo002/js/export_to_excel.js
@@ -12,8 +12,6 @@
     LOG_PREFIX: '[export]'
   };
 
-  const COLOR_ALPHA_PREFIX = 'FF';
-
   const debugLog = (...args) => {
     if (!CONFIG.DEBUG) return;
     console.log(CONFIG.LOG_PREFIX, ...args);
@@ -94,7 +92,9 @@
     const rgb = parseRgb(value);
     if (!rgb || rgb.a === 0) return null;
     const toHex = (n) => n.toString(16).padStart(2, '0').toUpperCase();
-    return `${COLOR_ALPHA_PREFIX}${toHex(rgb.r)}${toHex(rgb.g)}${toHex(rgb.b)}`;
+    const alphaValue = Math.max(0, Math.min(255, Math.round(rgb.a * 255)));
+    const alphaHex = toHex(alphaValue);
+    return `${alphaHex}${toHex(rgb.r)}${toHex(rgb.g)}${toHex(rgb.b)}`;
   };
 
   const widthToBorderStyle = (widthPx, cssStyle) => {


### PR DESCRIPTION
## Summary
- compute ARGB alpha values using the parsed color transparency when exporting
- remove the unused constant prefix now that alpha is calculated per color

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db9a5d878c83319964aa32a8b3941c