### PR TITLE
Add mapping for CSS border styles when exporting to Excel

### DIFF
--- a/demo002/js/export_to_excel.js
+++ b/demo002/js/export_to_excel.js
@@ -98,10 +98,35 @@
 
   const widthToBorderStyle = (widthPx, cssStyle) => {
     if (!widthPx || widthPx <= 0.5) return null;
-    if (!cssStyle || cssStyle === 'none' || cssStyle === 'hidden') return null;
-    if (widthPx < 1.5) return 'thin';
-    if (widthPx < 2.5) return 'medium';
-    return 'thick';
+    const normalizedStyle = (cssStyle || '').toLowerCase();
+    if (!normalizedStyle || normalizedStyle === 'none' || normalizedStyle === 'hidden') return null;
+
+    const styleByWidth = () => {
+      if (widthPx < 1.5) return 'thin';
+      if (widthPx < 2.5) return 'medium';
+      return 'thick';
+    };
+
+    switch (normalizedStyle) {
+      case 'solid':
+        return styleByWidth();
+      case 'dashed':
+        return widthPx < 2 ? 'dashed' : 'mediumDashed';
+      case 'dotted':
+        return widthPx < 2 ? 'dotted' : 'mediumDashDotDot';
+      case 'double':
+        return 'double';
+      case 'dash-dot':
+      case 'dashdot':
+      case 'dot-dash':
+        return widthPx < 2 ? 'dashDot' : 'mediumDashDot';
+      case 'dash-dot-dot':
+      case 'dashdotdot':
+      case 'dot-dot-dash':
+        return widthPx < 2 ? 'dashDotDot' : 'mediumDashDotDot';
+      default:
+        return styleByWidth();
+    }
   };
 
   const normalizeEdges = (edges) => {


### PR DESCRIPTION
## Summary
- map CSS border styles such as dashed, dotted, and double to appropriate ExcelJS border styles
- retain width-based handling for solid borders while adjusting other styles based on thickness

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dba09081048331837266b2639c9719