### PR TITLE
Align row detail tables with header column widths

### DIFF
--- a/demo003/index.html
+++ b/demo003/index.html
@@ -405,6 +405,14 @@
         <tr>
           <td>
             <table class="fontblack9a item-table">
+              <colgroup>
+                <col style="width: 339px;">
+                <col style="width: 111px;">
+                <col style="width: 80px;">
+                <col style="width: 33px;">
+                <col style="width: 88px;">
+                <col style="width: 99px;">
+              </colgroup>
               <tbody>
                 <tr>
                   <td class="align-top">
@@ -432,6 +440,14 @@
         <tr>
           <td>
             <table class="fontblack9a item-table">
+              <colgroup>
+                <col style="width: 339px;">
+                <col style="width: 111px;">
+                <col style="width: 80px;">
+                <col style="width: 33px;">
+                <col style="width: 88px;">
+                <col style="width: 99px;">
+              </colgroup>
               <tbody>
                 <tr>
                   <td class="align-top">
@@ -464,6 +480,14 @@
         <tr>
           <td>
             <table class="fontblack9a item-table">
+              <colgroup>
+                <col style="width: 339px;">
+                <col style="width: 111px;">
+                <col style="width: 80px;">
+                <col style="width: 33px;">
+                <col style="width: 88px;">
+                <col style="width: 99px;">
+              </colgroup>
               <tbody>
                 <tr>
                   <td class="full-width-cell" colspan="6">
@@ -482,6 +506,14 @@
         <tr>
           <td>
             <table class="fontblack9a item-table">
+              <colgroup>
+                <col style="width: 339px;">
+                <col style="width: 111px;">
+                <col style="width: 80px;">
+                <col style="width: 33px;">
+                <col style="width: 88px;">
+                <col style="width: 99px;">
+              </colgroup>
               <tbody>
                 <tr>
                   <td class="align-top">
@@ -511,6 +543,14 @@
         <tr>
           <td>
             <table class="fontblack9a item-table">
+              <colgroup>
+                <col style="width: 339px;">
+                <col style="width: 111px;">
+                <col style="width: 80px;">
+                <col style="width: 33px;">
+                <col style="width: 88px;">
+                <col style="width: 99px;">
+              </colgroup>
               <tbody>
                 <tr>
                   <td class="full-width-cell" colspan="6">


### PR DESCRIPTION
## Summary
- add the same column width definitions to each item table so detail rows align with the header layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcb72490c48331b27a195879690eed